### PR TITLE
[docs] Add OctoAcme Project Management README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,41 @@
+# OctoAcme Project Management Docs
+
+## Overview
+This folder contains OctoAcme's project management process documentation. These docs describe how we initiate, plan, execute, release, and improve projects — giving teams a consistent, discoverable way to run and hand off work.
+
+OctoAcme’s approach emphasizes:
+- Customer-first thinking and measurable outcomes
+- Iterative delivery and small, testable increments
+- Clear ownership (PM, Product Lead, Developers, QA)
+- Data-informed decisions and continuous improvement
+- Documented risks, communication cadence, and playbooks
+
+## Quick Process Summary
+- Initiation: Create a one-pager to confirm problem, objectives, success metrics, stakeholders, and a go/no-go for planning.
+- Planning: Prioritize backlog, estimate, define the Definition of Done, and identify dependencies and risks.
+- Execution & Tracking: Use a project board, small PRs, CI gating, daily standups, and weekly delivery syncs to track progress.
+- Release & Deployment: Meet pre-release requirements, run smoke tests, use automated pipelines, and document rollback plans.
+- Retrospective & Improvement: Run retrospectives after sprints/releases/incidents and convert action items into backlog work.
+
+## Documents
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Project Planning](./octoacme-project-planning.md)
+- [Execution & Tracking](./octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](./octoacme-roles-and-personas.md)
+
+## How to use these docs
+- Use this README as an entry point for new contributors and stakeholders.
+- Keep the Project One-pager and release notes in each project repo.
+- Propose updates using the “Add Content to Project Management Process Docs” issue template (.github/ISSUE_TEMPLATE/).
+- When updating any doc, include: rationale, acceptance criteria, and link to relevant stakeholders.
+
+## Contributing
+- Use the existing issue template for doc updates:
+  - `.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml`
+- Proposed changes should include a brief summary, rationale, and suggested content.
+- For process changes with team impact, confirm with the Product Lead / PM before merging.
+


### PR DESCRIPTION
Adds docs/README.md as an entry point for OctoAcme process docs. Links to the Project Management docs and provides a brief process overview.\n\nCloses #2